### PR TITLE
render_header_footer

### DIFF
--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,6 +1,5 @@
 
-.exhibit-header
-  = image_tag "logo.png", class: "exhibit-header--logo",size: "180x50"
+= render 'shared/product_header'
 
 .exhibit-boby
   .exhibit-boby--container
@@ -89,13 +88,4 @@
             %a{href:"#"}>加盟店規約
             に同意したことになります。
 
-.exhibit-footer
-  .exhibit-footer--container
-    .exhibit-footer--container__menu
-      = link_to "プライバシーポリシー", "#"
-      = link_to "FURIMA利用規約", "#"
-      = link_to "特定商取引に関する表記", "#"
-    .exhibit-footer--container__logo
-      =link_to root_path do
-        = image_tag "logo.png", size: "120x30"
-      %p © FURIMA
+= render 'shared/product_footer'

--- a/app/views/shared/_product_footer.html.haml
+++ b/app/views/shared/_product_footer.html.haml
@@ -1,0 +1,10 @@
+.exhibit-footer
+  .exhibit-footer--container
+    .exhibit-footer--container__menu
+      = link_to "プライバシーポリシー", "#"
+      = link_to "FURIMA利用規約", "#"
+      = link_to "特定商取引に関する表記", "#"
+    .exhibit-footer--container__logo
+      =link_to root_path do
+        = image_tag "logo.png", size: "120x30"
+      %p © FURIMA

--- a/app/views/shared/_product_header.html.haml
+++ b/app/views/shared/_product_header.html.haml
@@ -1,0 +1,2 @@
+.exhibit-header
+  = image_tag "logo.png", class: "exhibit-header--logo",size: "180x50"


### PR DESCRIPTION
# what
header、footerを部分テンプレート化。
sharedに_product_header＆footerを作成。

# why
他のページでも使えるようにするため。