### PR TITLE
product-show-simple-format

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -58,7 +58,7 @@
               送料込み
       -# 商品説明
       .product-show-text
-        = @product.description
+        = simple_format(@product.description)
 
       -# 商品情報の内容
       .product-show-status


### PR DESCRIPTION
# what
商品説明蘭の空白や改行をそのまま反映させるように変更

# why
みやすくするため